### PR TITLE
adding build goal in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 	</dependencies>
 
 	<build>
+		<defaultGoal>package</defaultGoal>
 		<plugins>
 			<plugin>
 				<artifactId>maven-war-plugin</artifactId>

--- a/src/main/resources/ConfigurationHelloWorld.xml
+++ b/src/main/resources/ConfigurationHelloWorld.xml
@@ -16,7 +16,7 @@
 			<pipe
 				name="HelloWorld"
 				className="nl.nn.adapterframework.pipes.FixedResult"
-				returnString="Hello World"
+				returnString="Hellooooooooooooooooooooooo World"
 				>
 				<forward name="success" path="EXIT"/>
 			</pipe>

--- a/src/main/resources/ConfigurationHelloWorld.xml
+++ b/src/main/resources/ConfigurationHelloWorld.xml
@@ -16,7 +16,7 @@
 			<pipe
 				name="HelloWorld"
 				className="nl.nn.adapterframework.pipes.FixedResult"
-				returnString="Hellooooooooooooooooooooooo World"
+				returnString="Hello World"
 				>
 				<forward name="success" path="EXIT"/>
 			</pipe>


### PR DESCRIPTION
In the pom build section AWS needs a build goal, otherwise pipeline deployment leads to "Goal not specified error"; adding defaultGoal with value "package" ; value "install" also avoids the aws error. 